### PR TITLE
Remove cost_estimation_enabled

### DIFF
--- a/env.tf
+++ b/env.tf
@@ -1,10 +1,8 @@
 resource "scalr_environment" "env_tag" {
   name                    = "env_tag_${formatdate("DDMMYYYY", timestamp())}"
-  cost_estimation_enabled = true
   tag_ids                 = [scalr_tag.auto_tag.id]
 }
 
 resource "scalr_environment" "env_no_tag" {
   name                    = "env_no_tag_${formatdate("DDMMYYYY", timestamp())}"
-  cost_estimation_enabled = false
 }

--- a/report_module_usage.tf
+++ b/report_module_usage.tf
@@ -6,7 +6,6 @@
 resource "scalr_environment" "report_env" {
   count = 21
   name                            = "REPORTS_env_namespace_${count.index}"
-  cost_estimation_enabled         = false
 }
 
 resource "scalr_module" "report_module" {


### PR DESCRIPTION
cost_estimation_enabled  is unsupported argument for scalr_environment resource, it was deprecated due to changes in CE feature